### PR TITLE
AppViewModel 단일 인스턴스 공유 구현

### DIFF
--- a/composeApp/src/commonMain/kotlin/io/github/kez_lab/stopwatch_game/App.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/kez_lab/stopwatch_game/App.kt
@@ -1,10 +1,17 @@
 package io.github.kez_lab.stopwatch_game
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.lifecycle.viewmodel.compose.viewModel
 import io.github.kez_lab.stopwatch_game.theme.AppTheme
 import io.github.kez_lab.stopwatch_game.ui.navigation.AppNavigation
+import io.github.kez_lab.stopwatch_game.viewmodel.AppViewModel
 
 @Composable
 internal fun App() = AppTheme {
-    AppNavigation()
+    // 앱 전체에서 공유될 단일 AppViewModel 인스턴스 생성
+    val appViewModel: AppViewModel = viewModel()
+    
+    // ViewModel을 AppNavigation에 전달
+    AppNavigation(appViewModel = appViewModel)
 }

--- a/composeApp/src/commonMain/kotlin/io/github/kez_lab/stopwatch_game/ui/navigation/AppNavigation.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/kez_lab/stopwatch_game/ui/navigation/AppNavigation.kt
@@ -10,6 +10,7 @@ import io.github.kez_lab.stopwatch_game.ui.screens.game.play.GamePlayScreen
 import io.github.kez_lab.stopwatch_game.ui.screens.home.HomeScreen
 import io.github.kez_lab.stopwatch_game.ui.screens.player.PlayerRegistrationScreen
 import io.github.kez_lab.stopwatch_game.ui.screens.result.ResultScreen
+import io.github.kez_lab.stopwatch_game.viewmodel.AppViewModel
 import kotlinx.serialization.Serializable
 
 // 앱 내 라우트 정의
@@ -35,7 +36,7 @@ sealed class Routes(val route: String) {
  * 앱의 메인 네비게이션 구성요소
  */
 @Composable
-fun AppNavigation() {
+fun AppNavigation(appViewModel: AppViewModel) {
     val navController = rememberNavController()
 
     NavHost(
@@ -43,23 +44,24 @@ fun AppNavigation() {
         startDestination = Routes.Home::class
     ) {
         composable<Routes.Home> {
-            HomeScreen(navController = navController)
+            HomeScreen(navController = navController, appViewModel = appViewModel)
         }
         composable<Routes.PlayerRegistration> {
-            PlayerRegistrationScreen(navController = navController)
+            PlayerRegistrationScreen(navController = navController, appViewModel = appViewModel)
         }
         composable<Routes.GameSelection> {
-            GameSelectionScreen(navController = navController)
+            GameSelectionScreen(navController = navController, appViewModel = appViewModel)
         }
         composable<Routes.GamePlay> { backStackEntry ->
             val args = backStackEntry.toRoute<Routes.GamePlay>()
             GamePlayScreen(
                 navController = navController,
-                gameId = args.gameId
+                gameId = args.gameId,
+                appViewModel = appViewModel
             )
         }
         composable<Routes.Result> {
-            ResultScreen(navController = navController)
+            ResultScreen(navController = navController, appViewModel = appViewModel)
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/io/github/kez_lab/stopwatch_game/ui/screens/game/GameSelectionScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/kez_lab/stopwatch_game/ui/screens/game/GameSelectionScreen.kt
@@ -43,9 +43,10 @@ import io.github.kez_lab.stopwatch_game.viewmodel.AppViewModel
  * 게임 선택 화면
  */
 @Composable
-fun GameSelectionScreen(navController: NavHostController) {
-    val appViewModel: AppViewModel = viewModel()
-    
+fun GameSelectionScreen(
+    navController: NavHostController,
+    appViewModel: AppViewModel
+) {
     // 게임 목록
     val games = remember { GameRepository.games }
     

--- a/composeApp/src/commonMain/kotlin/io/github/kez_lab/stopwatch_game/ui/screens/game/play/GamePlayScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/kez_lab/stopwatch_game/ui/screens/game/play/GamePlayScreen.kt
@@ -72,8 +72,11 @@ enum class GameScreenState {
  * 게임 플레이 화면
  */
 @Composable
-fun GamePlayScreen(navController: NavHostController, gameId: String) {
-    val appViewModel: AppViewModel = viewModel()
+fun GamePlayScreen(
+    navController: NavHostController, 
+    gameId: String,
+    appViewModel: AppViewModel
+) {
     val timerViewModel: GameTimerViewModel = viewModel()
     val hapticFeedback = LocalHapticFeedback.current
 

--- a/composeApp/src/commonMain/kotlin/io/github/kez_lab/stopwatch_game/ui/screens/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/kez_lab/stopwatch_game/ui/screens/home/HomeScreen.kt
@@ -1,9 +1,10 @@
 package io.github.kez_lab.stopwatch_game.ui.screens.home
 
-import androidx.compose.animation.core.animateDp
-import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.tween
-import androidx.compose.animation.core.updateTransition
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.slideInVertically
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -11,7 +12,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Button
@@ -20,6 +20,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -36,11 +37,16 @@ import compose.icons.FeatherIcons
 import compose.icons.feathericons.PlayCircle
 import io.github.kez_lab.stopwatch_game.ui.navigation.Routes
 import kotlinx.coroutines.delay
+import io.github.kez_lab.stopwatch_game.viewmodel.AppViewModel
 
 enum class HomeAnimationStage { NONE, TITLE, SUBTITLE, BUTTON }
 
 @Composable
-fun HomeScreen(navController: NavHostController) {
+fun HomeScreen(
+    navController: NavHostController,
+    appViewModel: AppViewModel
+) {
+    val uiState by appViewModel.uiState.collectAsState()
     var stage by remember { mutableStateOf(HomeAnimationStage.NONE) }
 
     LaunchedEffect(Unit) {

--- a/composeApp/src/commonMain/kotlin/io/github/kez_lab/stopwatch_game/ui/screens/player/PlayerRegistrationScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/kez_lab/stopwatch_game/ui/screens/player/PlayerRegistrationScreen.kt
@@ -56,9 +56,10 @@ import io.github.kez_lab.stopwatch_game.viewmodel.AppViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun PlayerRegistrationScreen(navController: NavHostController) {
-    val appViewModel: AppViewModel = viewModel()
-
+fun PlayerRegistrationScreen(
+    navController: NavHostController,
+    appViewModel: AppViewModel
+) {
     val players = remember { mutableStateListOf<Player>() }
     var newPlayerName by remember { mutableStateOf("") }
     var isError by remember { mutableStateOf(false) }

--- a/composeApp/src/commonMain/kotlin/io/github/kez_lab/stopwatch_game/ui/screens/result/ResultScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/kez_lab/stopwatch_game/ui/screens/result/ResultScreen.kt
@@ -68,9 +68,10 @@ import kotlinx.coroutines.delay
  * 결과 화면
  */
 @Composable
-fun ResultScreen(navController: NavHostController) {
-    val appViewModel: AppViewModel = viewModel()
-
+fun ResultScreen(
+    navController: NavHostController,
+    appViewModel: AppViewModel
+) {
     // 앱 상태
     val uiState by appViewModel.uiState.collectAsState()
 


### PR DESCRIPTION
## 변경 사항
- App 컴포넌트에서 단일 AppViewModel 인스턴스를 생성하여 모든 화면에 전달
- 화면 간 데이터 일관성을 위해 AppViewModel을 매개변수로 전달하는 구조로 변경
- 각 화면 내부에서 AppViewModel을 개별적으로 생성하는 코드 제거

## 문제점
기존에는 모든 화면에서 각각 viewModel() 함수를 통해 AppViewModel을 생성하고 있었습니다. 이로 인해:
1. 화면 간 상태 공유가 제대로 이루어지지 않음
2. 플레이어 정보, 게임 결과 등의 데이터가 화면 전환 시 유실되는 문제 발생
3. 일관된 사용자 경험을 제공하기 어려움

## 해결 방법
1. App 컴포넌트에서 단일 AppViewModel 인스턴스를 생성
2. AppNavigation 컴포넌트에 AppViewModel을 매개변수로 전달
3. 각 화면에 AppViewModel을 매개변수로 전달하는 구조로 변경
4. 모든 화면에서 개별적으로 viewModel()을 호출하는 코드 제거

## 기대 효과
1. 화면 전환 시에도 일관된 상태 유지
2. 메모리 사용량 감소 (여러 인스턴스가 아닌 하나의 ViewModel만 사용)
3. 사용자 경험 개선
4. 코드 구조 개선 및 의존성 명확화

이번 변경은 모든 화면이 동일한 데이터 소스를 참조하도록 하여 앱의 상태 관리를 간소화하고 안정성을 향상시킵니다.