### PR TITLE
CompositionLocal을 사용하여 AppViewModel 공유 구현

### DIFF
--- a/composeApp/src/commonMain/kotlin/io/github/kez_lab/stopwatch_game/App.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/kez_lab/stopwatch_game/App.kt
@@ -1,10 +1,17 @@
 package io.github.kez_lab.stopwatch_game
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.lifecycle.viewmodel.compose.viewModel
 import io.github.kez_lab.stopwatch_game.theme.AppTheme
 import io.github.kez_lab.stopwatch_game.ui.navigation.AppNavigation
+import io.github.kez_lab.stopwatch_game.viewmodel.AppViewModel
 
 @Composable
 internal fun App() = AppTheme {
-    AppNavigation()
+    // 앱 전체에서 공유될 단일 AppViewModel 인스턴스 생성
+    val appViewModel: AppViewModel = viewModel()
+    
+    // ViewModel을 AppNavigation에 전달
+    AppNavigation(appViewModel = appViewModel)
 }

--- a/composeApp/src/commonMain/kotlin/io/github/kez_lab/stopwatch_game/App.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/kez_lab/stopwatch_game/App.kt
@@ -1,10 +1,11 @@
 package io.github.kez_lab.stopwatch_game
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.lifecycle.viewmodel.compose.viewModel
 import io.github.kez_lab.stopwatch_game.theme.AppTheme
 import io.github.kez_lab.stopwatch_game.ui.navigation.AppNavigation
+import io.github.kez_lab.stopwatch_game.ui.viewmodel.LocalAppViewModel
 import io.github.kez_lab.stopwatch_game.viewmodel.AppViewModel
 
 @Composable
@@ -12,6 +13,9 @@ internal fun App() = AppTheme {
     // 앱 전체에서 공유될 단일 AppViewModel 인스턴스 생성
     val appViewModel: AppViewModel = viewModel()
     
-    // ViewModel을 AppNavigation에 전달
-    AppNavigation(appViewModel = appViewModel)
+    // CompositionLocalProvider를 통해 앱 전체에 AppViewModel 제공
+    CompositionLocalProvider(LocalAppViewModel provides appViewModel) {
+        // 명시적으로 ViewModel을 전달할 필요 없음
+        AppNavigation()
+    }
 }

--- a/composeApp/src/commonMain/kotlin/io/github/kez_lab/stopwatch_game/ui/navigation/AppNavigation.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/kez_lab/stopwatch_game/ui/navigation/AppNavigation.kt
@@ -10,7 +10,6 @@ import io.github.kez_lab.stopwatch_game.ui.screens.game.play.GamePlayScreen
 import io.github.kez_lab.stopwatch_game.ui.screens.home.HomeScreen
 import io.github.kez_lab.stopwatch_game.ui.screens.player.PlayerRegistrationScreen
 import io.github.kez_lab.stopwatch_game.ui.screens.result.ResultScreen
-import io.github.kez_lab.stopwatch_game.viewmodel.AppViewModel
 import kotlinx.serialization.Serializable
 
 // 앱 내 라우트 정의
@@ -36,7 +35,7 @@ sealed class Routes(val route: String) {
  * 앱의 메인 네비게이션 구성요소
  */
 @Composable
-fun AppNavigation(appViewModel: AppViewModel) {
+fun AppNavigation() {
     val navController = rememberNavController()
 
     NavHost(
@@ -44,24 +43,23 @@ fun AppNavigation(appViewModel: AppViewModel) {
         startDestination = Routes.Home::class
     ) {
         composable<Routes.Home> {
-            HomeScreen(navController = navController, appViewModel = appViewModel)
+            HomeScreen(navController = navController)
         }
         composable<Routes.PlayerRegistration> {
-            PlayerRegistrationScreen(navController = navController, appViewModel = appViewModel)
+            PlayerRegistrationScreen(navController = navController)
         }
         composable<Routes.GameSelection> {
-            GameSelectionScreen(navController = navController, appViewModel = appViewModel)
+            GameSelectionScreen(navController = navController)
         }
         composable<Routes.GamePlay> { backStackEntry ->
             val args = backStackEntry.toRoute<Routes.GamePlay>()
             GamePlayScreen(
                 navController = navController,
-                gameId = args.gameId,
-                appViewModel = appViewModel
+                gameId = args.gameId
             )
         }
         composable<Routes.Result> {
-            ResultScreen(navController = navController, appViewModel = appViewModel)
+            ResultScreen(navController = navController)
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/io/github/kez_lab/stopwatch_game/ui/navigation/AppNavigation.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/kez_lab/stopwatch_game/ui/navigation/AppNavigation.kt
@@ -10,6 +10,7 @@ import io.github.kez_lab.stopwatch_game.ui.screens.game.play.GamePlayScreen
 import io.github.kez_lab.stopwatch_game.ui.screens.home.HomeScreen
 import io.github.kez_lab.stopwatch_game.ui.screens.player.PlayerRegistrationScreen
 import io.github.kez_lab.stopwatch_game.ui.screens.result.ResultScreen
+import io.github.kez_lab.stopwatch_game.viewmodel.AppViewModel
 import kotlinx.serialization.Serializable
 
 // 앱 내 라우트 정의
@@ -35,7 +36,7 @@ sealed class Routes(val route: String) {
  * 앱의 메인 네비게이션 구성요소
  */
 @Composable
-fun AppNavigation() {
+fun AppNavigation(appViewModel: AppViewModel) {
     val navController = rememberNavController()
 
     NavHost(
@@ -43,23 +44,24 @@ fun AppNavigation() {
         startDestination = Routes.Home::class
     ) {
         composable<Routes.Home> {
-            HomeScreen(navController = navController)
+            HomeScreen(navController = navController, appViewModel = appViewModel)
         }
         composable<Routes.PlayerRegistration> {
-            PlayerRegistrationScreen(navController = navController)
+            PlayerRegistrationScreen(navController = navController, appViewModel = appViewModel)
         }
         composable<Routes.GameSelection> {
-            GameSelectionScreen(navController = navController)
+            GameSelectionScreen(navController = navController, appViewModel = appViewModel)
         }
         composable<Routes.GamePlay> { backStackEntry ->
             val args = backStackEntry.toRoute<Routes.GamePlay>()
             GamePlayScreen(
                 navController = navController,
-                gameId = args.gameId
+                gameId = args.gameId,
+                appViewModel = appViewModel
             )
         }
         composable<Routes.Result> {
-            ResultScreen(navController = navController)
+            ResultScreen(navController = navController, appViewModel = appViewModel)
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/io/github/kez_lab/stopwatch_game/ui/screens/game/GameSelectionScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/kez_lab/stopwatch_game/ui/screens/game/GameSelectionScreen.kt
@@ -37,16 +37,16 @@ import compose.icons.feathericons.Shuffle
 import io.github.kez_lab.stopwatch_game.model.GameRepository
 import io.github.kez_lab.stopwatch_game.ui.components.GameCard
 import io.github.kez_lab.stopwatch_game.ui.navigation.Routes
-import io.github.kez_lab.stopwatch_game.viewmodel.AppViewModel
+import io.github.kez_lab.stopwatch_game.ui.viewmodel.LocalAppViewModel
 
 /**
  * 게임 선택 화면
  */
 @Composable
-fun GameSelectionScreen(
-    navController: NavHostController,
-    appViewModel: AppViewModel
-) {
+fun GameSelectionScreen(navController: NavHostController) {
+    // CompositionLocal을 통해 AppViewModel 접근
+    val appViewModel = LocalAppViewModel.current
+    
     // 게임 목록
     val games = remember { GameRepository.games }
     

--- a/composeApp/src/commonMain/kotlin/io/github/kez_lab/stopwatch_game/ui/screens/game/GameSelectionScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/kez_lab/stopwatch_game/ui/screens/game/GameSelectionScreen.kt
@@ -44,7 +44,6 @@ import io.github.kez_lab.stopwatch_game.ui.viewmodel.LocalAppViewModel
  */
 @Composable
 fun GameSelectionScreen(navController: NavHostController) {
-    // CompositionLocal을 통해 AppViewModel 접근
     val appViewModel = LocalAppViewModel.current
     
     // 게임 목록

--- a/composeApp/src/commonMain/kotlin/io/github/kez_lab/stopwatch_game/ui/screens/game/GameSelectionScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/kez_lab/stopwatch_game/ui/screens/game/GameSelectionScreen.kt
@@ -43,9 +43,10 @@ import io.github.kez_lab.stopwatch_game.viewmodel.AppViewModel
  * 게임 선택 화면
  */
 @Composable
-fun GameSelectionScreen(navController: NavHostController) {
-    val appViewModel: AppViewModel = viewModel()
-    
+fun GameSelectionScreen(
+    navController: NavHostController,
+    appViewModel: AppViewModel
+) {
     // 게임 목록
     val games = remember { GameRepository.games }
     

--- a/composeApp/src/commonMain/kotlin/io/github/kez_lab/stopwatch_game/ui/screens/game/play/GamePlayScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/kez_lab/stopwatch_game/ui/screens/game/play/GamePlayScreen.kt
@@ -76,7 +76,6 @@ fun GamePlayScreen(
     navController: NavHostController, 
     gameId: String
 ) {
-    // CompositionLocal을 통해 AppViewModel 접근
     val appViewModel = LocalAppViewModel.current
     val timerViewModel: GameTimerViewModel = viewModel()
     val hapticFeedback = LocalHapticFeedback.current

--- a/composeApp/src/commonMain/kotlin/io/github/kez_lab/stopwatch_game/ui/screens/game/play/GamePlayScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/kez_lab/stopwatch_game/ui/screens/game/play/GamePlayScreen.kt
@@ -72,8 +72,11 @@ enum class GameScreenState {
  * 게임 플레이 화면
  */
 @Composable
-fun GamePlayScreen(navController: NavHostController, gameId: String) {
-    val appViewModel: AppViewModel = viewModel()
+fun GamePlayScreen(
+    navController: NavHostController, 
+    gameId: String,
+    appViewModel: AppViewModel
+) {
     val timerViewModel: GameTimerViewModel = viewModel()
     val hapticFeedback = LocalHapticFeedback.current
 

--- a/composeApp/src/commonMain/kotlin/io/github/kez_lab/stopwatch_game/ui/screens/game/play/GamePlayScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/kez_lab/stopwatch_game/ui/screens/game/play/GamePlayScreen.kt
@@ -53,7 +53,7 @@ import io.github.kez_lab.stopwatch_game.model.GameType
 import io.github.kez_lab.stopwatch_game.ui.components.TimerButton
 import io.github.kez_lab.stopwatch_game.ui.components.TimerDisplay
 import io.github.kez_lab.stopwatch_game.ui.navigation.Routes
-import io.github.kez_lab.stopwatch_game.viewmodel.AppViewModel
+import io.github.kez_lab.stopwatch_game.ui.viewmodel.LocalAppViewModel
 import io.github.kez_lab.stopwatch_game.viewmodel.GameTimerViewModel
 import io.github.kez_lab.stopwatch_game.viewmodel.TimerUiState
 import kotlinx.coroutines.delay
@@ -74,9 +74,10 @@ enum class GameScreenState {
 @Composable
 fun GamePlayScreen(
     navController: NavHostController, 
-    gameId: String,
-    appViewModel: AppViewModel
+    gameId: String
 ) {
+    // CompositionLocal을 통해 AppViewModel 접근
+    val appViewModel = LocalAppViewModel.current
     val timerViewModel: GameTimerViewModel = viewModel()
     val hapticFeedback = LocalHapticFeedback.current
 

--- a/composeApp/src/commonMain/kotlin/io/github/kez_lab/stopwatch_game/ui/screens/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/kez_lab/stopwatch_game/ui/screens/home/HomeScreen.kt
@@ -1,9 +1,10 @@
 package io.github.kez_lab.stopwatch_game.ui.screens.home
 
-import androidx.compose.animation.core.animateDp
-import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.tween
-import androidx.compose.animation.core.updateTransition
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.slideInVertically
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -11,7 +12,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Button
@@ -20,6 +20,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -36,11 +37,16 @@ import compose.icons.FeatherIcons
 import compose.icons.feathericons.PlayCircle
 import io.github.kez_lab.stopwatch_game.ui.navigation.Routes
 import kotlinx.coroutines.delay
+import io.github.kez_lab.stopwatch_game.viewmodel.AppViewModel
 
 enum class HomeAnimationStage { NONE, TITLE, SUBTITLE, BUTTON }
 
 @Composable
-fun HomeScreen(navController: NavHostController) {
+fun HomeScreen(
+    navController: NavHostController,
+    appViewModel: AppViewModel
+) {
+    val uiState by appViewModel.uiState.collectAsState()
     var stage by remember { mutableStateOf(HomeAnimationStage.NONE) }
 
     LaunchedEffect(Unit) {

--- a/composeApp/src/commonMain/kotlin/io/github/kez_lab/stopwatch_game/ui/screens/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/kez_lab/stopwatch_game/ui/screens/home/HomeScreen.kt
@@ -1,10 +1,9 @@
 package io.github.kez_lab.stopwatch_game.ui.screens.home
 
-import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.animateDp
+import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.tween
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.slideInVertically
-import androidx.compose.foundation.Image
+import androidx.compose.animation.core.updateTransition
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -12,6 +11,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Button
@@ -20,7 +20,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -37,16 +36,11 @@ import compose.icons.FeatherIcons
 import compose.icons.feathericons.PlayCircle
 import io.github.kez_lab.stopwatch_game.ui.navigation.Routes
 import kotlinx.coroutines.delay
-import io.github.kez_lab.stopwatch_game.viewmodel.AppViewModel
 
 enum class HomeAnimationStage { NONE, TITLE, SUBTITLE, BUTTON }
 
 @Composable
-fun HomeScreen(
-    navController: NavHostController,
-    appViewModel: AppViewModel
-) {
-    val uiState by appViewModel.uiState.collectAsState()
+fun HomeScreen(navController: NavHostController) {
     var stage by remember { mutableStateOf(HomeAnimationStage.NONE) }
 
     LaunchedEffect(Unit) {
@@ -84,7 +78,10 @@ fun HomeScreen(
 private fun Title(visible: Boolean) {
     val transition = updateTransition(targetState = visible, label = "TitleTransition")
     val alpha by transition.animateFloat({ tween(400) }, label = "alpha") { if (it) 1f else 0f }
-    val offsetY by transition.animateDp({ tween(400) }, label = "offsetY") { if (it) 0.dp else 30.dp }
+    val offsetY by transition.animateDp(
+        { tween(400) },
+        label = "offsetY"
+    ) { if (it) 0.dp else 30.dp }
 
     Text(
         text = "TimeBattle",

--- a/composeApp/src/commonMain/kotlin/io/github/kez_lab/stopwatch_game/ui/screens/player/PlayerRegistrationScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/kez_lab/stopwatch_game/ui/screens/player/PlayerRegistrationScreen.kt
@@ -52,14 +52,14 @@ import compose.icons.feathericons.UserPlus
 import compose.icons.feathericons.Users
 import io.github.kez_lab.stopwatch_game.model.Player
 import io.github.kez_lab.stopwatch_game.ui.navigation.Routes
-import io.github.kez_lab.stopwatch_game.viewmodel.AppViewModel
+import io.github.kez_lab.stopwatch_game.ui.viewmodel.LocalAppViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun PlayerRegistrationScreen(
-    navController: NavHostController,
-    appViewModel: AppViewModel
-) {
+fun PlayerRegistrationScreen(navController: NavHostController) {
+    // CompositionLocal을 통해 AppViewModel 접근
+    val appViewModel = LocalAppViewModel.current
+    
     val players = remember { mutableStateListOf<Player>() }
     var newPlayerName by remember { mutableStateOf("") }
     var isError by remember { mutableStateOf(false) }

--- a/composeApp/src/commonMain/kotlin/io/github/kez_lab/stopwatch_game/ui/screens/player/PlayerRegistrationScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/kez_lab/stopwatch_game/ui/screens/player/PlayerRegistrationScreen.kt
@@ -40,9 +40,7 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
-import androidx.navigation.NavOptions
 import compose.icons.FeatherIcons
 import compose.icons.feathericons.ArrowRight
 import compose.icons.feathericons.Plus
@@ -57,9 +55,8 @@ import io.github.kez_lab.stopwatch_game.ui.viewmodel.LocalAppViewModel
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun PlayerRegistrationScreen(navController: NavHostController) {
-    // CompositionLocal을 통해 AppViewModel 접근
     val appViewModel = LocalAppViewModel.current
-    
+
     val players = remember { mutableStateListOf<Player>() }
     var newPlayerName by remember { mutableStateOf("") }
     var isError by remember { mutableStateOf(false) }

--- a/composeApp/src/commonMain/kotlin/io/github/kez_lab/stopwatch_game/ui/screens/player/PlayerRegistrationScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/kez_lab/stopwatch_game/ui/screens/player/PlayerRegistrationScreen.kt
@@ -56,9 +56,10 @@ import io.github.kez_lab.stopwatch_game.viewmodel.AppViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun PlayerRegistrationScreen(navController: NavHostController) {
-    val appViewModel: AppViewModel = viewModel()
-
+fun PlayerRegistrationScreen(
+    navController: NavHostController,
+    appViewModel: AppViewModel
+) {
     val players = remember { mutableStateListOf<Player>() }
     var newPlayerName by remember { mutableStateOf("") }
     var isError by remember { mutableStateOf(false) }

--- a/composeApp/src/commonMain/kotlin/io/github/kez_lab/stopwatch_game/ui/screens/result/ResultScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/kez_lab/stopwatch_game/ui/screens/result/ResultScreen.kt
@@ -68,9 +68,8 @@ import kotlinx.coroutines.delay
  */
 @Composable
 fun ResultScreen(navController: NavHostController) {
-    // CompositionLocal을 통해 AppViewModel 접근
     val appViewModel = LocalAppViewModel.current
-    
+
     // 앱 상태
     val uiState by appViewModel.uiState.collectAsState()
 

--- a/composeApp/src/commonMain/kotlin/io/github/kez_lab/stopwatch_game/ui/screens/result/ResultScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/kez_lab/stopwatch_game/ui/screens/result/ResultScreen.kt
@@ -68,9 +68,10 @@ import kotlinx.coroutines.delay
  * 결과 화면
  */
 @Composable
-fun ResultScreen(navController: NavHostController) {
-    val appViewModel: AppViewModel = viewModel()
-
+fun ResultScreen(
+    navController: NavHostController,
+    appViewModel: AppViewModel
+) {
     // 앱 상태
     val uiState by appViewModel.uiState.collectAsState()
 

--- a/composeApp/src/commonMain/kotlin/io/github/kez_lab/stopwatch_game/ui/screens/result/ResultScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/kez_lab/stopwatch_game/ui/screens/result/ResultScreen.kt
@@ -49,7 +49,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
 import compose.icons.FeatherIcons
 import compose.icons.feathericons.ArrowLeft
@@ -61,17 +60,17 @@ import compose.icons.feathericons.Target
 import io.github.kez_lab.stopwatch_game.model.GameType
 import io.github.kez_lab.stopwatch_game.model.Player
 import io.github.kez_lab.stopwatch_game.ui.navigation.Routes
-import io.github.kez_lab.stopwatch_game.viewmodel.AppViewModel
+import io.github.kez_lab.stopwatch_game.ui.viewmodel.LocalAppViewModel
 import kotlinx.coroutines.delay
 
 /**
  * 결과 화면
  */
 @Composable
-fun ResultScreen(
-    navController: NavHostController,
-    appViewModel: AppViewModel
-) {
+fun ResultScreen(navController: NavHostController) {
+    // CompositionLocal을 통해 AppViewModel 접근
+    val appViewModel = LocalAppViewModel.current
+    
     // 앱 상태
     val uiState by appViewModel.uiState.collectAsState()
 

--- a/composeApp/src/commonMain/kotlin/io/github/kez_lab/stopwatch_game/ui/viewmodel/ViewModelProvider.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/kez_lab/stopwatch_game/ui/viewmodel/ViewModelProvider.kt
@@ -1,0 +1,13 @@
+package io.github.kez_lab.stopwatch_game.ui.viewmodel
+
+import androidx.compose.runtime.ProvidableCompositionLocal
+import androidx.compose.runtime.compositionLocalOf
+import io.github.kez_lab.stopwatch_game.viewmodel.AppViewModel
+
+/**
+ * AppViewModel을 위한 CompositionLocal
+ * 앱 전체에서 단일 AppViewModel 인스턴스에 접근하기 위한 컨텍스트 제공
+ */
+val LocalAppViewModel: ProvidableCompositionLocal<AppViewModel> = compositionLocalOf {
+    error("LocalAppViewModel이 제공되지 않았습니다. CompositionLocalProvider에서 AppViewModel을 설정해야 합니다.")
+} 


### PR DESCRIPTION
## 변경 사항
- CompositionLocal을 사용하여 AppViewModel 인스턴스를 앱 전체에 제공
- 각 화면에서 매개변수 전달 대신 CompositionLocal을 통해 AppViewModel 접근
- ViewModelProvider.kt 생성 및 LocalAppViewModel 정의
- 모든 화면에서 LocalAppViewModel.current로 ViewModel 공유 접근 구현

## 장점
1. **Parameter Drilling 제거**
   - 네비게이션 컴포넌트와 각 화면에 AppViewModel을 직접 전달하는 복잡한 코드 구조 제거
   - 모든 화면에서 일관된 방식으로 ViewModel에 접근 가능

2. **의존성 주입 단순화**
   - CompositionLocal을 통해 앱 전체에 필요한 의존성을 자동으로 제공
   - 새로운 화면을 추가할 때 별도의 ViewModel 주입 코드가 필요 없음

3. **관심사 분리 개선**
   - 네비게이션 로직과 데이터 관리 로직이 명확하게 분리됨
   - 각 컴포넌트는 단일 책임 원칙에 더 잘 부합함

## 비교: 직접 매개변수 전달 vs. CompositionLocal
### 직접 매개변수 전달 (이전)
```kotlin
fun AppNavigation(appViewModel: AppViewModel) {
    // 각 화면에 ViewModel을 매개변수로 전달
    composable(...) {
        HomeScreen(navController, appViewModel)
    }
}
```

### CompositionLocal 사용 (변경 후)
```kotlin
fun AppNavigation() {
    // 각 화면에서 LocalAppViewModel.current로 직접 접근
    composable(...) {
        HomeScreen(navController)
    }
}
```

이 방식을 사용하면 ViewModel이 필요한 모든 컴포지션 지점에서 쉽게 접근할 수 있으며, 계층 구조가 깊어도 매개변수 전달 없이 ViewModel을 사용할 수 있습니다.